### PR TITLE
Kan 94

### DIFF
--- a/src/app/(dashboard)/calendar/page.tsx
+++ b/src/app/(dashboard)/calendar/page.tsx
@@ -27,6 +27,7 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
+import { Badge } from "@/components/ui/badge";
 import { cl } from "@fullcalendar/core/internal-common";
 import { useFirebaseAuth } from "@/services/authService";
 
@@ -63,8 +64,14 @@ export default function Calendar() {
   };
 
   const renderEventContent = (eventInfo: EventContentArg) => {
-    const { isBackgroundEvent, location, clientName, title, description } =
-      eventInfo.event.extendedProps;
+    const {
+      isBackgroundEvent,
+      location,
+      clientName,
+      title,
+      description,
+      paid,
+    } = eventInfo.event.extendedProps;
     const classNames = eventInfo.event.classNames || [];
     const view = eventInfo.view.type;
 
@@ -85,10 +92,13 @@ export default function Calendar() {
             </HoverCardTrigger>
             <HoverCardContent>
               <div className="px-2 py-1">
+                <Badge className={paid ? "bg-green-500" : "bg-red-500"}>
+                  {paid ? "Paid" : "unpaid"}
+                </Badge>
+                {/* <div className="text-xs">{`payment status : ${paid}`}</div> */}
                 <div className="text-sm font-semibold">
                   {`Notes : ${description}`}
                 </div>
-                <div className="text-xs">{` Location : ${location}`}</div>
               </div>
             </HoverCardContent>
           </HoverCard>
@@ -508,6 +518,8 @@ export default function Calendar() {
     if (checkOverlap(info.event, allEvents)) {
       info.el.classList.add("overlap-event");
     }
+
+    // add a popOver to the event here
   };
 
   return (

--- a/src/comp/CreateBookingsFormDialog.tsx
+++ b/src/comp/CreateBookingsFormDialog.tsx
@@ -44,6 +44,7 @@ import { EventInput } from "@/interfaces/types";
 import { fetchBookingTypes } from "@/lib/converters/bookingTypes";
 import { CaretSortIcon, CheckIcon } from "@radix-ui/react-icons";
 import { fetchClients } from "@/lib/converters/clients";
+import { Switch } from "@headlessui/react";
 
 interface CreateBookingsFormDialogProps {
   isOpen: boolean;
@@ -59,6 +60,7 @@ interface CreateBookingsFormDialogProps {
     date?: string;
     startTime: string;
     endTime: string;
+    paid: boolean;
     recurrence?: {
       daysOfWeek: number[];
       startTime: string;
@@ -92,6 +94,8 @@ const CreateBookingsFormDialog: React.FC<CreateBookingsFormDialogProps> = ({
   const [daysOfWeek, setDaysOfWeek] = useState<number[]>([]);
   const [startRecur, setStartRecur] = useState("");
   const [endRecur, setEndRecur] = useState("");
+  // Payment status state
+  const [paid, setPaid] = useState(false); // Defaults to false (Unpaid)
   // Location state
   const [location, setLocation] = useState("");
   // Booking type state
@@ -119,6 +123,7 @@ const CreateBookingsFormDialog: React.FC<CreateBookingsFormDialogProps> = ({
   useEffect(() => {
     if (event) {
       // setTitle(event.title || "");
+      setPaid(event.paid || false);
       setDescription(event.description || "");
       setLocation(event.location || "");
       setDate(
@@ -234,6 +239,7 @@ const CreateBookingsFormDialog: React.FC<CreateBookingsFormDialogProps> = ({
       date: showDateSelector ? date : undefined,
       startTime,
       endTime,
+      paid,
       recurrence: isRecurring
         ? {
             daysOfWeek,
@@ -264,6 +270,7 @@ const CreateBookingsFormDialog: React.FC<CreateBookingsFormDialogProps> = ({
     setBookingFee("");
     setClient("");
     setClientId("");
+    setPaid(false);
     onClose();
   };
 
@@ -416,6 +423,34 @@ const CreateBookingsFormDialog: React.FC<CreateBookingsFormDialogProps> = ({
                 </PopoverContent>
               </Popover>
             </div>
+
+            <div className="space-y-2">
+              <Label className="block text-sm font-medium text-gray-700">
+                Payment Status
+              </Label>
+              {/* <p className="mt-2 text-sm text-gray-500">
+              Toggle to set the event as Paid or Unpaid.
+            </p> */}
+              <div className="flex items-center space-x-2">
+                <span className="text-sm font-medium text-gray-700">
+                  {paid ? "Paid" : "Unpaid"}
+                </span>
+                <Switch
+                  checked={paid}
+                  onChange={setPaid}
+                  className={`${
+                    paid ? "bg-blue-600" : "bg-gray-200"
+                  } relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none`}
+                >
+                  <span
+                    className={`${
+                      paid ? "translate-x-6" : "translate-x-1"
+                    } inline-block h-4 w-4 transform bg-white rounded-full transition-transform`}
+                  />
+                </Switch>
+              </div>
+            </div>
+
             <div className="space-y-1">
               <Label className="block text-sm font-medium text-gray-700">
                 Select or type in Custom Booking Type

--- a/src/comp/EventFormModal.tsx
+++ b/src/comp/EventFormModal.tsx
@@ -278,6 +278,7 @@ const EventFormDialog: React.FC<EventFormDialogProps> = ({
     setBookingFee("");
     setClient("");
     setClientId("");
+    setPaid(false);
     onClose();
   };
 

--- a/src/comp/tabs/create_bookings.tsx
+++ b/src/comp/tabs/create_bookings.tsx
@@ -826,7 +826,7 @@ export default function CreateBookings() {
 
               <TableHead>Client</TableHead>
 
-              <TableHead>Title</TableHead>
+              <TableHead>Type</TableHead>
               <TableHead>Notes</TableHead>
               <TableHead>Actions</TableHead>
             </TableRow>

--- a/src/comp/tabs/create_bookings.tsx
+++ b/src/comp/tabs/create_bookings.tsx
@@ -202,6 +202,7 @@ export default function CreateBookings() {
             endDay: new Date(
               dtstart.getTime() + (end.getTime() - start.getTime())
             ).toLocaleDateString("en-US", { weekday: "long" }),
+            paid: data.paid,
             recurrence: data.recurrence,
             exceptions: data.exceptions,
           });
@@ -220,6 +221,7 @@ export default function CreateBookings() {
             startDay: start.toLocaleDateString("en-US", { weekday: "long" }),
             endDate: end,
             endDay: end.toLocaleDateString("en-US", { weekday: "long" }),
+            paid: data.paid,
           });
         }
       });
@@ -438,6 +440,7 @@ export default function CreateBookings() {
     date?: string;
     startTime: string;
     endTime: string;
+    paid: boolean;
     recurrence?: {
       daysOfWeek: number[];
       startRecur: string; // YYYY-MM-DD
@@ -492,7 +495,7 @@ export default function CreateBookings() {
 
           start: startDateTime, // Save in UTC
           end: endDateTime, // Save in UTC
-
+          paid: eventData.paid,
           created_at: new Date(), // Timestamp of creation
           updated_at: new Date(), // Timestamp of last update
         };
@@ -520,6 +523,7 @@ export default function CreateBookings() {
           startDate,
           startTime: eventData.startTime,
           endTime: eventData.endTime,
+          paid: eventData.paid,
           recurrence: {
             daysOfWeek: eventData.recurrence?.daysOfWeek || [],
             startRecur: eventData.recurrence?.startRecur || startDate,

--- a/src/comp/tabs/create_bookings.tsx
+++ b/src/comp/tabs/create_bookings.tsx
@@ -828,6 +828,8 @@ export default function CreateBookings() {
                 </div>
               </TableHead>
 
+              <TableHead>Duration</TableHead>
+
               <TableHead>Client</TableHead>
 
               <TableHead>Booking Type</TableHead>
@@ -902,6 +904,29 @@ export default function CreateBookings() {
                       {displayTimeWithOffset(event.end)}
                     </div>
                   )}
+                </TableCell>
+
+                <TableCell>
+                  {(() => {
+                    const duration = moment.duration(
+                      moment(event.end).diff(moment(event.start))
+                    );
+                    const hours = Math.floor(duration.asHours());
+                    const minutes = duration.minutes();
+
+                    let formattedDuration = "";
+                    if (hours > 0) {
+                      formattedDuration += `${hours} h `;
+                    }
+                    if (minutes > 0) {
+                      formattedDuration += `${minutes} m`;
+                    }
+                    if (hours === 0 && minutes === 0) {
+                      formattedDuration = "0 m";
+                    }
+
+                    return formattedDuration.trim();
+                  })()}
                 </TableCell>
 
                 <TableCell>

--- a/src/comp/tabs/create_bookings.tsx
+++ b/src/comp/tabs/create_bookings.tsx
@@ -256,6 +256,10 @@ export default function CreateBookings() {
       );
       let updates: any = {};
 
+      if (field === "clientName") {
+        updates = { [field]: editedValue };
+      }
+
       const getUserTimeZoneOffset = () => {
         // Returns the time zone offset in hours (e.g., -7 for PDT)
         return new Date().getTimezoneOffset() / 60;
@@ -783,6 +787,8 @@ export default function CreateBookings() {
                 </div>
               </TableHead>
 
+              <TableHead>Client</TableHead>
+
               <TableHead>Title</TableHead>
               <TableHead>Notes</TableHead>
               <TableHead>Actions</TableHead>
@@ -853,6 +859,31 @@ export default function CreateBookings() {
                     >
                       {displayTimeWithOffset(event.end)}
                     </div>
+                  )}
+                </TableCell>
+
+                <TableCell>
+                  {editingCell?.id === event.id &&
+                  editingCell?.field === "clientName" ? (
+                    <Input
+                      value={editedValue}
+                      onChange={handleInputChange}
+                      onBlur={handleBlur}
+                      autoFocus
+                    />
+                  ) : (
+                    <span
+                      onClick={() =>
+                        handleCellClick(
+                          event.id!,
+                          "clientName",
+                          event.clientName,
+                          !!event.recurrence
+                        )
+                      }
+                    >
+                      {event.clientName}
+                    </span>
                   )}
                 </TableCell>
 

--- a/src/comp/tabs/create_bookings.tsx
+++ b/src/comp/tabs/create_bookings.tsx
@@ -297,6 +297,10 @@ export default function CreateBookings() {
         }
       }
 
+      if (field === "fee") {
+        updates = { [field]: parseFloat(editedValue) };
+      }
+
       const getUserTimeZoneOffset = () => {
         // Returns the time zone offset in hours (e.g., -7 for PDT)
         return new Date().getTimezoneOffset() / 60;
@@ -826,7 +830,8 @@ export default function CreateBookings() {
 
               <TableHead>Client</TableHead>
 
-              <TableHead>Type</TableHead>
+              <TableHead>Booking Type</TableHead>
+              <TableHead>Fee</TableHead>
               <TableHead>Notes</TableHead>
               <TableHead>Actions</TableHead>
             </TableRow>
@@ -946,6 +951,31 @@ export default function CreateBookings() {
                     >
                       {event.title || "Untitled"}
                     </div>
+                  )}
+                </TableCell>
+
+                <TableCell>
+                  {editingCell?.id === event.id &&
+                  editingCell?.field === "fee" ? (
+                    <Input
+                      value={editedValue}
+                      onChange={handleInputChange}
+                      onBlur={handleBlur}
+                      autoFocus
+                    />
+                  ) : (
+                    <span
+                      onClick={() =>
+                        handleCellClick(
+                          event.id!,
+                          "fee",
+                          event.fee.toString(),
+                          !!event.recurrence
+                        )
+                      }
+                    >
+                      {event.fee}
+                    </span>
                   )}
                 </TableCell>
 

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/src/lib/converters/events.ts
+++ b/src/lib/converters/events.ts
@@ -69,6 +69,7 @@ const eventConverter: FirestoreDataConverter<EventInput> = {
       className: data.isBackgroundEvent ? "fc-bg-event" : "",
       recurrence: data.recurrence, // in nolan's code it was undefined
       exdate: data.exceptions || [],
+      paid: data.paid,
       // exceptions: data.exceptions,
       // originalEventId: data.originalEventId,
       // isInstance: data.isInstance,


### PR DESCRIPTION
This is a fix for Three tickets : 

- https://nolansingroy.atlassian.net/browse/KAN-94
- https://nolansingroy.atlassian.net/browse/KAN-96
- https://nolansingroy.atlassian.net/browse/KAN-85

- Clients now are imported inside the booking dialog
- user can add an existing client or a new client 
- clients show in the calendar page 
- paid status shows when hovering over the calendar events blocks 
- there is a Z index issue with the hovering container when two or more events are adjacent to each other. this will be fixed in a separate ticker. 
- clients are editable on the booking list view 
- added fees to the bookings list view 
- added duration to the bookings list view 
- changed title to booking type 
- implemented editing client , fees, in bookings list view 
- when client edits a client name , then the edit function will check if the edited client is already existing in the clients collection, if yes then it will edit the clientName of the event object to the edited client name and also will edit the clientId of the events collection to the found collection id of the clients collection. If this was not the case, then it will change the clientName of the events object to the edited name and will set the clientId of the events collection to an empty string. in this way we can easily find all the details of the client from inside the events object without an error. 
- there is still an issue with editing the booking type, which should also be implemented the same way above, i need to do that in a separate ticket ..  