### PR TITLE
feat:fixed recurring events and disabled startRecure in calendar modal

### DIFF
--- a/src/app/(dashboard)/calendar/page.tsx
+++ b/src/app/(dashboard)/calendar/page.tsx
@@ -95,10 +95,24 @@ export default function Calendar() {
     const classNames = eventInfo.event.classNames || [];
     const view = eventInfo.view.type;
 
+    // console.log("==================================", eventInfo);
+
+    // i want to remove fc-bg-event from the background events
+    if (isBackgroundEvent) {
+    }
+
+    if (classNames.includes("bg-event-mirror")) {
+      return (
+        <div className="bg-blue-200 opacity-50 text-black p-1 rounded text-center border">
+          {eventInfo.event.title}
+        </div>
+      );
+    }
+
     // if (classNames.includes("bg-event-mirror")) {
     //   return (
-    //     <div className="bg-blue-200 opacity-50 text-black p-1 rounded text-center border border-blue-500">
-    //       {eventInfo.event.title}
+    //     <div className="bg-black opacity-50 text-black p-1 rounded text-center h-max w-max">
+    //       {description}
     //     </div>
     //   );
     // }
@@ -591,7 +605,7 @@ export default function Calendar() {
           start: startDateTime, // Save in UTC
           end: endDateTime, // Save in UTC
           description,
-          display: isBackgroundEvent ? "inverse-background" : "auto",
+          display: isBackgroundEvent ? "background" : "auto",
           className: isBackgroundEvent ? "custom-bg-event" : "",
           isBackgroundEvent,
           startDate: startDateTime, // Save in UTC
@@ -933,40 +947,39 @@ export default function Calendar() {
                     if (event.isBackgroundEvent) {
                       return {
                         ...event,
-                        // title: event.title,
+                        title: event.title,
                         type: event.type,
                         typeId: event.typeId,
                         location: event.location,
-                        rrule: {
-                          freq: "weekly",
-                          interval: 1,
-                          byweekday: event.recurrence.daysOfWeek
-                            ? event.recurrence.daysOfWeek.map(
-                                (day) =>
-                                  ["SU", "MO", "TU", "WE", "TH", "FR", "SA"][
-                                    day
-                                  ]
-                              )
-                            : undefined,
-                          dtstart: new Date(event.start).toISOString(),
-                          until: event.recurrence.endRecur
-                            ? new Date(event.recurrence.endRecur).toISOString()
-                            : undefined,
-                        },
+                        // rrule: {
+                        //   freq: "weekly",
+                        //   interval: 1,
+                        //   byweekday: event.recurrence.daysOfWeek
+                        //     ? event.recurrence.daysOfWeek.map(
+                        //         (day) =>
+                        //           ["SU", "MO", "TU", "WE", "TH", "FR", "SA"][
+                        //             day
+                        //           ]
+                        //       )
+                        //     : undefined,
+                        //   dtstart: new Date(event.start).toISOString(),
+                        //   until: event.recurrence.endRecur
+                        //     ? new Date(event.recurrence.endRecur).toISOString()
+                        //     : undefined,
+                        // },
                         startTime: event.recurrence.startTime,
                         endTime: event.recurrence.endTime,
                         display: "inverse-background",
-                        groupId: "1234",
+                        groupId: `1234`,
                         uniqueId: `${event.id}-${index}`,
-                        color: event.isBackgroundEvent
-                          ? "#c5c5c5"
-                          : event.color,
+                        color: "#C5C5C5",
                         duration: formattedDuration,
+                        // className: "bg-event-mirror",
                       };
                     } else {
                       return {
                         ...event,
-                        // title: event.title,
+                        title: event.title,
                         type: event.type,
                         typeId: event.typeId,
                         location: event.location,
@@ -989,11 +1002,9 @@ export default function Calendar() {
                         startTime: event.recurrence.startTime,
                         endTime: event.recurrence.endTime,
                         display: "auto",
-                        groupId: event.id,
+                        // groupId: event.id,
                         uniqueId: `${event.id}-${index}`,
-                        color: event.isBackgroundEvent
-                          ? "#c5c5c5"
-                          : event.color,
+                        color: event.color,
                         duration: formattedDuration,
                       };
                     }
@@ -1001,26 +1012,25 @@ export default function Calendar() {
                     if (event.isBackgroundEvent) {
                       return {
                         ...event,
-                        // title: event.title,
+                        title: event.title,
                         type: event.type,
                         typeId: event.typeId,
                         location: event.location,
                         display: "inverse-background",
-                        groupId: "1234",
+                        groupId: `1234`,
                         uniqueId: `${event.id}-${index}`,
-                        color: event.isBackgroundEvent
-                          ? "#c5c5c5"
-                          : event.color,
+                        color: "#C5C5C5",
+                        // className: "bg-event-mirror",
                       };
                     } else {
                       return {
                         ...event,
-                        // title: event.title,
+                        title: event.title,
                         type: event.type,
                         typeId: event.typeId,
                         location: event.location,
                         display: "auto",
-                        groupId: event.id,
+                        // groupId: event.id,
                         uniqueId: `${event.id}-${index}`,
                         color: event.color,
                       };

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -77,9 +77,13 @@
   }
 }
 
-.fc-bg-event {
-  @apply bg-fc-bg-event;
-}
+/* .fc-event.fc-event-start.fc-event-end.fc-event-today.fc-event-future.fc-bg-event {
+  background-color: #c5c5c5 !important;  */
+/* } */
+
+/* .fc-bg-event {
+  @apply bg-white;
+} */
 
 /* .fc-month-view .fc-day .fc-event-dot {
   color: var(--fc-event-bg-color);
@@ -177,3 +181,23 @@
 .fc-popover.fc-more-popover.fc-day.fc-day-today {
   background-color: #fff !important;
 }
+
+/*greying out only the weekview days*/
+/* .fc-timeGridWeek-view .fc-timegrid-col {
+  background-color: #e9e9e9 !important;
+} */
+
+/*whitening the axis of the weekview*/
+/* .fc-timeGridWeek-view .fc-timegrid-col.fc-timegrid-axis {
+  background-color: #fff !important;
+} */
+
+/*greying the axis of the dayview*/
+/* .fc-timeGridDay-view .fc-timegrid-col {
+  background-color: #e9e9e9 !important;
+} */
+
+/*whitening the axis of the dayview*/
+/* .fc-timeGridDay-view .fc-timegrid-col.fc-timegrid-axis {
+  background-color: #fff !important;
+} */

--- a/src/comp/EventFormModal.tsx
+++ b/src/comp/EventFormModal.tsx
@@ -7,6 +7,7 @@ import React, {
   MouseEvent,
   useEffect,
   useCallback,
+  use,
 } from "react";
 import {
   Dialog,
@@ -158,9 +159,18 @@ const EventFormDialog: React.FC<EventFormDialogProps> = ({
         setDaysOfWeek(event.recurrence.daysOfWeek || []);
         setStartRecur(event.recurrence.startRecur || "");
         setEndRecur(event.recurrence.endRecur || "");
+      } else {
+        setStartRecur(
+          event.startDate ? event.startDate.toISOString().split("T")[0] : ""
+        );
       }
     }
   }, [event]);
+
+  // handle startRecur change when date changes
+  useEffect(() => {
+    setStartRecur(date);
+  }, [date]);
 
   const fetchBookings = useCallback(async () => {
     if (authUser) {
@@ -403,6 +413,17 @@ const EventFormDialog: React.FC<EventFormDialogProps> = ({
       handleClientSelect(client, ""); // Set the client with the typed name if it's not in the list
     }
     setClientsPopoverOpen(false);
+  };
+
+  // handle the date change
+  const handleDateChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const selectedDate = e.target.value;
+    setDate(selectedDate);
+
+    // If the event is recurring, set the start recurrence date to the selected date
+    if (isRecurring) {
+      setStartRecur(selectedDate);
+    }
   };
 
   return (
@@ -807,6 +828,7 @@ const EventFormDialog: React.FC<EventFormDialogProps> = ({
                     onChange={(e: ChangeEvent<HTMLInputElement>) =>
                       setStartRecur(e.target.value)
                     }
+                    disabled
                   />
                 </div>
                 <div className="flex flex-col">
@@ -832,9 +854,7 @@ const EventFormDialog: React.FC<EventFormDialogProps> = ({
               <Input
                 type="date"
                 value={date}
-                onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                  setDate(e.target.value)
-                }
+                onChange={handleDateChange}
                 className="px-2 py-2 text-center rounded-md border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
               />
             </div>

--- a/src/comp/tabs/availability.tsx
+++ b/src/comp/tabs/availability.tsx
@@ -931,9 +931,9 @@ export default function Availability() {
                     </DropdownMenuTrigger>
                     <DropdownMenuContent>
                       {/* Clone Option */}
-                      <DropdownMenuItem onClick={() => handleCloneClick(event)}>
+                      {/* <DropdownMenuItem onClick={() => handleCloneClick(event)}>
                         Clone
-                      </DropdownMenuItem>
+                      </DropdownMenuItem> */}
                       {/*  Delete Option */}
                       <DropdownMenuItem
                         onClick={() => handleDeleteClick(event.id!)}

--- a/src/lib/converters/events.ts
+++ b/src/lib/converters/events.ts
@@ -71,7 +71,7 @@ const eventConverter: FirestoreDataConverter<EventInput> = {
       description: data.description || "",
       display: data.isBackgroundEvent ? "background" : "auto",
       isBackgroundEvent: !!data.isBackgroundEvent,
-      className: data.isBackgroundEvent ? "fc-bg-event" : "",
+      className: data.isBackgroundEvent ? "" : "",
       recurrence: data.recurrence, // in nolan's code it was undefined
       exdate: data.exceptions || [],
       paid: data.paid,

--- a/src/lib/functions/renderEvents.tsx
+++ b/src/lib/functions/renderEvents.tsx
@@ -1,0 +1,89 @@
+import { EventContentArg } from "@fullcalendar/core";
+import tippy from "tippy.js";
+import "tippy.js/dist/tippy.css";
+import React from "react";
+
+const renderContent = (eventInfo: EventContentArg, tippyInstances: Map<string, any>) => {
+  const { isBackgroundEvent, clientName, title, description, paid, type } =
+    eventInfo.event.extendedProps;
+
+  const backgroundColor = eventInfo.backgroundColor || "#000000";
+  const viewType = eventInfo.view.type;
+  const isMonthView = viewType.includes("dayGridMonth");
+
+  const renderMonthViewEvent = () => {
+    const defaultStartTimeUTC = new Date(eventInfo.event.startStr);
+    const timezoneOffsetHours = -(new Date().getTimezoneOffset() / 60);
+    const defaultStartTimeLocal = new Date(defaultStartTimeUTC);
+    defaultStartTimeLocal.setHours(
+      defaultStartTimeUTC.getHours() - timezoneOffsetHours
+    );
+
+    const formattedStartTime = defaultStartTimeLocal.toLocaleTimeString(
+      "en-US",
+      {
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: true,
+      }
+    );
+
+    return (
+      <div className="flex gap-1 items-center w-full overflow-hidden">
+        <div
+          className="w-2 h-2 rounded-full flex-shrink-0"
+          style={{ backgroundColor }}
+        ></div>
+        <div className="flex items-center truncate w-full">
+          <span className="text-xs">{formattedStartTime}</span>
+          <span className="text-xs truncate ml-2">{clientName}</span>
+        </div>
+      </div>
+    );
+  };
+
+  const renderDefaultEvent = () => (
+    <div>
+      <span
+        className="underline"
+        ref={(el) => {
+          if (el) {
+            const existingInstance = tippyInstances.get(eventInfo.event.id);
+            if (existingInstance) {
+              existingInstance.destroy();
+            }
+
+            const tippyInstance = tippy(el, {
+              trigger: "mouseenter",
+              touch: "hold",
+              allowHTML: true,
+              content: `
+                <div class="tippy-content">
+                  <p class="${paid ? "paid-status" : "unpaid-status"}">
+                    <strong>${paid ? "Paid" : "Unpaid"}</strong>
+                  </p>
+                  <p><strong>Notes:</strong> ${description}</p>
+                </div>
+              `,
+              theme: "custom",
+            });
+
+            tippyInstances.set(eventInfo.event.id, tippyInstance);
+          }
+        }}
+      >
+        <span className="flex items-center truncate w-full">
+          {clientName || "No name"}
+        </span>
+      </span>
+    </div>
+  );
+
+  if (isMonthView && !isBackgroundEvent) {
+    return renderMonthViewEvent();
+  }
+
+  return renderDefaultEvent();
+};
+
+export default renderContent;


### PR DESCRIPTION

- This is a fix for issue KAN-93

The issue was that recurring availabilities was not working well. I have reconstructed availabilities so that they render in the correct time, duration and in the correct blocks in the calendar. 
- i have removed the clone availabilities functionality on the Availabilities list view 
- I have disabled the startRecure input and fed it with the start date so that the user does not select both. 
- i have made sure that availabilities can be deleted as a batch , or individually without any issues. 
- More testing would help. 

Initial testing results: 
- in the initial testing , i found out the clone availabilities is not working so i disabled it 
- i found out that changing start and end times using the availabilities list view have inconsistent results. The time input sometimes work as expected, however the issue happens when we change it multiple times or start from am and change to pm. probably the input does not recognize that it should be within the same day , so sometimes it pushes the availability to the next day. 
- i found out that we should make sure the start time is always before the end Time, hence it should not allow edit if this rule is violated.  