### PR TITLE
fix:removing the seconds part of the calendar display start time

### DIFF
--- a/src/app/dashboard/profile/_components/profile-view.tsx
+++ b/src/app/dashboard/profile/_components/profile-view.tsx
@@ -15,7 +15,6 @@ import { Period } from "@/components/inputs/time-picker-utils"; // Import the Pe
 function convertTo24HourFormat(
   hours: number,
   minutes: number,
-  seconds: number,
   period: string
 ): string {
   if (period === "PM" && hours < 12) {
@@ -26,19 +25,18 @@ function convertTo24HourFormat(
   }
   return `${hours.toString().padStart(2, "0")}:${minutes
     .toString()
-    .padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+    .padStart(2, "0")}:00`;
 }
 
 function convertTo12HourFormat(time24h: string): {
   hours: number;
   minutes: number;
-  seconds: number;
   period: string;
 } {
-  let [hours, minutes, seconds] = time24h.split(":").map(Number);
+  let [hours, minutes] = time24h.split(":").map(Number);
   const period = hours >= 12 ? "PM" : "AM";
   hours = hours % 12 || 12; // Convert 0 to 12 for 12 AM
-  return { hours, minutes, seconds, period };
+  return { hours, minutes, period };
 }
 
 export default function ProfileView() {
@@ -72,12 +70,10 @@ export default function ProfileView() {
             lastName: userData.lastName || "",
             email: userData.email || "",
           });
-          const { hours, minutes, seconds, period } =
-            convertTo12HourFormat(startTime);
+          const { hours, minutes, period } = convertTo12HourFormat(startTime);
           const date = new Date();
           date.setHours(hours);
           date.setMinutes(minutes);
-          date.setSeconds(seconds);
           setSelectedDate(date);
           setPeriod(period as Period); // Set the period state
         }
@@ -93,12 +89,10 @@ export default function ProfileView() {
       if (authUser && selectedDate) {
         const hours = selectedDate.getHours();
         const minutes = selectedDate.getMinutes();
-        const seconds = selectedDate.getSeconds();
         const period = hours >= 12 ? "PM" : "AM";
         const time24h = convertTo24HourFormat(
           hours % 12 || 12,
           minutes,
-          seconds,
           period
         );
         const userDocRef = doc(db, "users", authUser.uid);

--- a/src/components/inputs/time-picker-12h-demo.tsx
+++ b/src/components/inputs/time-picker-12h-demo.tsx
@@ -21,7 +21,6 @@ export function TimePicker12Demo({
 }: TimePickerDemoProps) {
   const minuteRef = React.useRef<HTMLInputElement>(null);
   const hourRef = React.useRef<HTMLInputElement>(null);
-  const secondRef = React.useRef<HTMLInputElement>(null);
   const periodRef = React.useRef<HTMLButtonElement>(null);
 
   return (
@@ -50,20 +49,6 @@ export function TimePicker12Demo({
           setDate={setDate}
           ref={minuteRef}
           onLeftFocus={() => hourRef.current?.focus()}
-          onRightFocus={() => secondRef.current?.focus()}
-        />
-      </div>
-      <div className="grid gap-1 text-center">
-        <Label htmlFor="seconds" className="text-xs">
-          Seconds
-        </Label>
-        <TimePickerInput
-          picker="seconds"
-          id="seconds12"
-          date={date}
-          setDate={setDate}
-          ref={secondRef}
-          onLeftFocus={() => minuteRef.current?.focus()}
           onRightFocus={() => periodRef.current?.focus()}
         />
       </div>
@@ -77,7 +62,7 @@ export function TimePicker12Demo({
           date={date}
           setDate={setDate}
           ref={periodRef}
-          onLeftFocus={() => secondRef.current?.focus()}
+          onLeftFocus={() => minuteRef.current?.focus()}
         />
       </div>
     </div>


### PR DESCRIPTION
related to issue ticket 118 

updates :
- remove the seconds part of the calendar display time in profile page 